### PR TITLE
Await ACK before deleting connection from the set of connections

### DIFF
--- a/ovip-0010.md
+++ b/ovip-0010.md
@@ -230,7 +230,7 @@ Received OpenVASP *Envelopes* of type ACK are processed as per following steps.
 1. Read `envelopeACK` value from the *Payload* of the *Envelope* received.
 2. Lookup item in the Outbound Envelope Queue (see 5.4) based on matching `envelopeID`/`envelopeACK` values
 3. If a match can be found with the isCLOSE flag set to `False`, then delete the item from the queue.
-4. If a match can be found with the isCLOSE flag set to `True`, then:
+4. If a match can be found with the isCLOSE flag set to `True`, then:  
 * delete respective item in the *Connection* set (see 5.3) based on matching `connection`/`connectionID` values, and
 * delete the item from the queue.
 

--- a/ovip-0010.md
+++ b/ovip-0010.md
@@ -228,11 +228,12 @@ If required, the *Envelope* is acknowledged as per following steps.
 Received OpenVASP *Envelopes* of type ACK are processed as per following steps.
 
 1. Read `envelopeACK` value from the *Payload* of the *Envelope* received.
-2. Lookup item in the Outbound Envelope Queue (see 5.4) based on matching `envelopeID`/`envelopeACK` values
+2. Lookup item in the Outbound Envelope Queue (see 5.4) based on matching `envelopeID`/`envelopeACK` values.
 3. If a match can be found with the isCLOSE flag set to `False`, then delete the item from the queue.
-4. If a match can be found with the isCLOSE flag set to `True`, then:  
-* delete respective item in the *Connection* set (see 5.3) based on matching `connection`/`connectionID` values, and
-* delete the item from the queue.
+4. If a match can be found with the isCLOSE flag set to `True`, then:
+
+   delete respective item in the *Connection* set (see 5.3) based on matching `connection`/`connectionID` values, and
+   delete the item from the queue.
 
 ## 6. Implementing the Session Layer
 

--- a/ovip-0010.md
+++ b/ovip-0010.md
@@ -231,8 +231,8 @@ Received OpenVASP *Envelopes* of type ACK are processed as per following steps.
 2. Lookup item in the Outbound Envelope Queue (see 5.4) based on matching `envelopeID`/`envelopeACK` values
 3. If a match can be found with the isCLOSE flag set to `False`, then delete the item from the queue.
 4. If a match can be found with the isCLOSE flag set to `True`, then:
-   a) Delete respective item in the *Connection* set (see 5.3) based on matching `connection`/`connectionID` values; and
-   b) Delete the item from the queue.
+..* delete respective item in the *Connection* set (see 5.3) based on matching `connection`/`connectionID` values, and
+..* delete the item from the queue.
 
 ## 6. Implementing the Session Layer
 

--- a/ovip-0010.md
+++ b/ovip-0010.md
@@ -232,8 +232,9 @@ Received OpenVASP *Envelopes* of type ACK are processed as per following steps.
 3. If a match can be found with the isCLOSE flag set to `False`, then delete the item from the queue.
 4. If a match can be found with the isCLOSE flag set to `True`, then:
 
-   delete respective item in the *Connection* set (see 5.3) based on matching `connection`/`connectionID` values, and
-   delete the item from the queue.
+   a) delete respective item in the *Connection* set (see 5.3) based on matching `connection`/`connectionID` values, and
+   
+   b) delete the item from the queue.
 
 ## 6. Implementing the Session Layer
 

--- a/ovip-0010.md
+++ b/ovip-0010.md
@@ -166,6 +166,7 @@ Queue items have the following properties:
 | `expiry`     | Time when the waiting period for the acknowledgement of `envelope` ends and it is resent |
 | `resends`    | Number of times `envelope` had to be resent                  |
 | `connection` | Identifier of the associated *Connection*                    |
+| `isCLOSE`    | Flag whether the Envelope is of type CLOSE (see 4.1.1)       |
 
 #### 5.4.1. Periodical Check
 
@@ -228,7 +229,9 @@ Received OpenVASP *Envelopes* of type ACK are processed as per following steps.
 
 1. Read `envelopeACK` value from the *Payload* of the *Envelope* received.
 2. Lookup item in the Outbound Envelope Queue (see 5.4) based on matching `envelopeID`/`envelopeACK` values
-3. If a match can be found, delete the item from the queue.
+3. If a match can be found,
+   a) If its flag isCLOSE is `True`, Delete respective item in the *Connection* set (see 5.3) based on matching `connection`/`connectionID` values.
+   b) Delete the item from the queue.
 
 ## 6. Implementing the Session Layer
 
@@ -302,6 +305,7 @@ The reader is recommended to consult OVIP-7 to understand the session model in f
    | `expiry`     | Current time + 900 seconds          |
    | `resends`    | `0`                                 |
    | `connection` | `connectionIdentifier`              |
+   | `isCLOSE`    | `False`                             |
    
 10. Make the *Node* listen to incoming *Envelopes* associated to this *Connection*.
 
@@ -389,6 +393,7 @@ Send acknowledgement (see 5.6).
    | `expiry`     | Current time + 900 seconds          |
    | `resends`    | `0`                                 |
    | `connection` | `connectionID`                      |
+   | `isCLOSE`    | `False`                             |
 
 4. Send Envelope created in step 2.
 
@@ -511,10 +516,9 @@ On the level of *Node* *Connections*, terminating a session (see OVIP-7, 4.3) or
    | `expiry`     | Current time + 900 seconds          |
    | `resends`    | `0`                                 |
    | `connection` | `connectionID`                      |
+   | `isCLOSE`    | `True`                              |
    
 4. Send Envelope created in step 2.
-
-5. Delete respective item in the *Connection* set (see 5.3) based on matching `connection`/`connectionID` values.
 
 ##### 6.3.1.3. Feedback to Session Layer
 
@@ -576,6 +580,7 @@ Send acknowledgement (see 5.6).
    | `expiry`     | Current time + 900 seconds          |
    | `resends`    | `0`                                 |
    | `connection` | `connectionID`                      |
+   | `isCLOSE`    | `False`                             |
 
 4. Send Envelope created in step 2.
 

--- a/ovip-0010.md
+++ b/ovip-0010.md
@@ -231,8 +231,8 @@ Received OpenVASP *Envelopes* of type ACK are processed as per following steps.
 2. Lookup item in the Outbound Envelope Queue (see 5.4) based on matching `envelopeID`/`envelopeACK` values
 3. If a match can be found with the isCLOSE flag set to `False`, then delete the item from the queue.
 4. If a match can be found with the isCLOSE flag set to `True`, then:
-..* delete respective item in the *Connection* set (see 5.3) based on matching `connection`/`connectionID` values, and
-..* delete the item from the queue.
+* delete respective item in the *Connection* set (see 5.3) based on matching `connection`/`connectionID` values, and
+* delete the item from the queue.
 
 ## 6. Implementing the Session Layer
 

--- a/ovip-0010.md
+++ b/ovip-0010.md
@@ -229,8 +229,9 @@ Received OpenVASP *Envelopes* of type ACK are processed as per following steps.
 
 1. Read `envelopeACK` value from the *Payload* of the *Envelope* received.
 2. Lookup item in the Outbound Envelope Queue (see 5.4) based on matching `envelopeID`/`envelopeACK` values
-3. If a match can be found,
-   a) If its flag isCLOSE is `True`, Delete respective item in the *Connection* set (see 5.3) based on matching `connection`/`connectionID` values.
+3. If a match can be found with the isCLOSE flag set to `False`, then delete the item from the queue.
+4. If a match can be found with the isCLOSE flag set to `True`, then:
+   a) Delete respective item in the *Connection* set (see 5.3) based on matching `connection`/`connectionID` values; and
    b) Delete the item from the queue.
 
 ## 6. Implementing the Session Layer


### PR DESCRIPTION
CLOSE envelopes need to be acknowledged. However, previous specification erroneously did not allow to receive the ACK as the connection (and its topic needed to listen for the ACK) was already deleted as part of termination/abortion.
Changes introduce a flag in the Outbound Envelope Queue for envelopes of type CLOSE and delete connections only after the corresponding ACK has been received.