### PR TITLE
fix Transfer multiplicator

### DIFF
--- a/ovip-0014.md
+++ b/ovip-0014.md
@@ -69,7 +69,7 @@ Responder (Beneficiary VASP)
 | :--------- | :------------------ | :--------- | :--------------- | :---- | :---------------- |
 | Version    |                     | `version`  | String           | 1..1  | fixed value `1.0` |
 | Reply code |                     | `rcode`    | dt.TFR.200.rcode | 1..1  |                   |
-| Transfer   |                     | `transfer` |                  | 1..1  |                   |
+| Transfer   |                     | `transfer` |                  | 0..1  |                   |
 |            | Destination address | `destadr`  | String           | 1..1  |                   |
 | Comment    |                     | `comment`  | String           | 0..1  |                   |
 


### PR DESCRIPTION
The `destaddr` is only useful if the transfer has
been accepted. Therefore, the `Transfer` field
should be optional. Otherwise, implementations
are forced to add dummy values for `destaddr` for
all non-accepted cases.