### PR TITLE
ovip-0007: declare ecdhpk field in section 2.2.1

### DIFF
--- a/ovip-0007.md
+++ b/ovip-0007.md
@@ -54,6 +54,7 @@ VASP receiving a *Message*.
 | Message identifier | `msgid`    | Hex(128-bit) | Randomly set                                   |
 | Session identifier | `session`  | Hex(128-bit) | See 4.1                                        |
 | Message type       | `type`     | String       | See 4.1 / 4.2 / 4.3 / 4.4                      |
+| ECDH Public Key    | `ecdhpk`   | Hex(33-Bytes)| See 4.1 / 4.2                                  |
 
 #### 2.2.2. Signature
 


### PR DESCRIPTION
The `ecdhpk` field is mentioned in sections 4.1 and 4.2
but its declaration in the header table in section 2.2.1
is missing.