### PR TITLE
ovip-0007: make signature verification portable

### DIFF
--- a/ovip-0007.md
+++ b/ovip-0007.md
@@ -33,14 +33,18 @@ VASP receiving a *Message*.
 
 ### 2.2. Message Structure
 
-*Messages* are JSON files as specified in RFC 8259 and must contain the following elements:
+_Messages_ are serialized into bytes and must contain the following elements:
+
+1. `Signature` (fixed length, see 2.2.2)
+2. `Content` encoded in JSON as specified in RFC 8259 (see below)
 
 | Level 1   | Level 2 | Name      | Type   | Description                                    |
 | --------- | ------- | --------- | ------ | ---------------------------------------------- |
 | Content   |         | `content` | Object |                                                |
 |           | Header  | `header`  | Object | See 2.2.1                                      |
 |           | Body    | `body`    | Object | Contains elements depending on message type    |
-| Signature |         | `sig`     | String | See 2.2.2                                      |
+
+The signature is prepended to the serialized `Content` bytes.
 
 #### 2.2.1 Header
 


### PR DESCRIPTION
Before, a verifier needed to deserialize the JSON
in order to extract the signature and then re-serialize
the `Content` back into JSON in order to verify the
signature. Because JSON lacks of a canonical form the
re-serialization into JSON is implementation defined
and therefore not portable.

To work around this limitation the signature is removed
from the JSON document and prepanded to the encoded
JSON bytes. That way signature verification can be
performed without deserialization.