### PR TITLE
ovip-0007: clarify simplified JSON message

### DIFF
--- a/ovip-0007.md
+++ b/ovip-0007.md
@@ -38,11 +38,10 @@ _Messages_ are serialized into bytes and must contain the following elements:
 1. `Signature` (fixed length, see 2.2.2)
 2. `Content` encoded in JSON as specified in RFC 8259 (see below)
 
-| Level 1   | Level 2 | Name      | Type   | Description                                    |
-| --------- | ------- | --------- | ------ | ---------------------------------------------- |
-| Content   |         | `content` | Object |                                                |
-|           | Header  | `header`  | Object | See 2.2.1                                      |
-|           | Body    | `body`    | Object | Contains elements depending on message type    |
+| Level 1 | Name      | Type   | Description                                    |
+| ------- | --------- | ------ | ---------------------------------------------- |
+| Header  | `header`  | Object | See 2.2.1                                      |
+| Body    | `body`    | Object | Contains elements depending on message type    |
 
 The signature is prepended to the serialized `Content` bytes.
 
@@ -50,7 +49,7 @@ The signature is prepended to the serialized `Content` bytes.
 
 `header` is a JSON object and must contain the following elements:
 
-| Level 3            | Name       | Type         | Description                                    |
+| Level 2            | Name       | Type         | Description                                    |
 | ------------------ | ---------- | ------------ | ---------------------------------------------- |
 | Version            | `version`  | String       | Fixed value: `1.0`                             |
 | Sender             | `sender`   | Hex(32-bit)  | VASP Identifier of the *Sender*                |
@@ -190,7 +189,7 @@ When receiving a `Session Abort` *Message* from the *Responder*, the *Initiator'
 
 The *Message* must contain the following elements in its `header` object:
 
-| Level 2 | Level 3            | Name      | Type         | Description        |
+| Level 1 | Level 2            | Name      | Type         | Description        |
 | ------- | ------------------ | --------- | ------------ | ------------------ |
 | Header  |                    |           |              |                    |
 |         | Session identifier | `session` | Hex(128-bit) | Randomly set       |
@@ -201,7 +200,7 @@ The *Message* must contain the following elements in its `header` object:
 
 The *Message* must contain the following elements in its `header` and `body` objects:
 
-| Level 2 | Level 3            | Name      | Type         | Description                         |
+| Level 1 | Level 2            | Name      | Type         | Description                         |
 | ------- | ------------------ | --------- | ------------ | ----------------------------------- |
 | Header  |                    |           |              |                                     |
 |         | Session identifier | `session` | Hex(128-bit) | Value received in `Session Request` |
@@ -223,7 +222,7 @@ The *Message* must contain the following elements in its `header` and `body` obj
 
 The *Message* must contain the following elements in its `header` object:
 
-| Level 2 | Level 3            | Name      | Type         | Description                         |
+| Level 1 | Level 2            | Name      | Type         | Description                         |
 | ------- | ------------------ | --------- | ------------ | ----------------------------------- |
 | Header  |                    |           |              |                                     |
 |         | Session identifier | `session` | Hex(128-bit) | Value received in `Session Request` |
@@ -233,7 +232,7 @@ The *Message* must contain the following elements in its `header` object:
 
 The *Message* must contain the following elements in its `header` and `body` objects:
 
-| Level 2 | Level 3            | Name      | Type         | Description                         |
+| Level 1 | Level 2            | Name      | Type         | Description                         |
 | ------- | ------------------ | --------- | ------------ | ----------------------------------- |
 | Header  |                    |           |              |                                     |
 |         | Session identifier | `session` | Hex(128-bit) | Value received in `Session Request` |


### PR DESCRIPTION
Because the signature has been moved out of the
JSON message the `Content` JSON object should be
flattened.