### PR TITLE
Add OVIP 17 (InterVASP)

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -81,7 +81,7 @@ We thank the Bitcoin community for introducing this process to handle standard i
 | OpenVASP Core Data Types
 | David Riegelnig
 | Standard
-| Accepted
+| Superseded
 |-
 | [[ovip-0014.md|14]]
 |
@@ -101,6 +101,13 @@ We thank the Bitcoin community for introducing this process to handle standard i
 |
 | Waku for Message Layer
 | Felix Laufenberg
+| Standard
+| Accepted
+|-
+| [[ovip-0017.md|17]]
+|
+| Increase InterVASP IVMS101 compatibility
+| Lucas Betschart
 | Standard
 | Accepted
 |}

--- a/ovip-0017.md
+++ b/ovip-0017.md
@@ -1,0 +1,231 @@
+```pseudocode
+OVIP: 17
+Title: Increase InterVASP IVMS101 compatibility
+Author: Lucas Betschart <lucas@21analytics.ch>
+Discussions-To: https://github.com/OpenVASP/ovips/issues/27
+Status: Accepted
+Type: Standard
+Created: 2021-07-17
+```
+
+# Abstract
+
+This OVIP adjusts the naming of the core data types for the OpenVASP protocol to increase compatibility with InterVASP IVMS101. It supersedes [OVIP 13](ovip-0013.md).
+
+# Specification
+
+## 1. Core Data Types (Top Level Element Structure)
+
+### 1.1. VASP
+
+| Level 1                 | Name      | Type       | Mult. | Rules |
+| :---------------------- | :-------- | :--------- | :---- | :---- |
+| VASP Identifier         | `vaspid`  | String(12) | 1..1  | 1     |
+| Natural person          | `naturalPerson` | see [2.1](#21-natural-person)    | 0..1  | 2     |
+| Legal person            | `legalPerson`   | see [2.2](#22-legal-person)    | 0..1  | 2, 3  |
+| Address                 | `geographicAddress` | see [2.3](#23-address)    | 1..1  |       |
+| National identification | `nationalIdentification`      | see [2.4](#24-national-identification-type)    | 1..*  | 3     |
+
+**Rules:**
+
+1. `vaspid` must be a VASP Identifier as specified in [OVIP 2](ovip-0002.md).
+2. Either `naturalPerson` or `legalPerson` must be present, but not both.
+3. If `legalPerson` is present, `nationalIdentification` must contain at least one sub element where `nationalIdentifierType` (see [2.4](#24-national-identification-type)) has one of the following values: `RAID`, `LEIX`, `TXID` or `MISC`.
+
+### 1.2. Originator
+
+| Level 1                 | Name      | Type    | Mult. | Rules |
+| :---------------------- | :-------- | :------ | :---- | :---- |
+| Natural person          | `naturalPerson` | see [2.1](#21-natural-person) | 0..1  | 1, 2  |
+| Legal person            | `legalPerson`   | see [2.2](#22-legal-person) | 0..1  | 1, 3  |
+| Address                 | `geographicAddress` | see [2.3](#23-address) | 0..1  | 2     |
+| National identification | `nationalIdentification`      | see [2.4](#24-national-identification-type) | 0..*  | 2, 3  |
+| Customer identification | `cid`     | see [2.5](#25-customer-identification-type) | 0..*  | 2     |
+
+**Rules:**
+
+1. Either `naturalPerson` or `legalPerson` must be present, but not both.
+2. Either `geographicAddress` or `nationalIdentification` or `cid` or `dateAndPlaceOfBirth` (sub element of `natural`, see [2.1](#21-natural-person)) must be present. More than one can be present.
+3. If `legalPerson` and `nationalIdentification` are both present, `nationalIdentification` must contain at least one sub element where `nationalIdentifierType` (see [2.4](#24-national-identification-type)) has one of the following values: `RAID`, `LEIX`, `TXID` or `MISC`.
+
+### 1.3. Beneficiary
+
+| Level 1                 | Name      | Type    | Mult. | Rules |
+| :---------------------- | :-------- | :------ | :---- | :---- |
+| Natural person          | `naturalPerson` | see [2.1](#21-natural-person) | 0..1  | 1     |
+| Legal person            | `legalPerson`   | see [2.2](#22-legal-person) | 0..1  | 1     |
+| Address                 | `geographicAddress`  | see [2.3](#23-address) | 0..1  |       |
+| National identification | `nationalIdentification`      | see [2.4](#24-national-identification-type) | 0..*  |       |
+| Customer identification | `cid`     | see [2.5](#25-customer-identification-type) | 0..*  |       |
+
+**Rules:**
+
+1. Either `naturalPerson` or `legalPerson` must be present, but not both.
+
+## 2. Sub Elements
+
+### 2.1. Natural Person
+
+| Level 2              | Name             | Type      | Mult.  | Rules |
+| :------------------- | :--------------- | :-------- | :----- | :---- |
+| Name                 | `nameIdentifier`           | see 2.1.1 | 1..*   | 1     |
+| Name local           | `localNameIdentifier`     | see 2.1.1 | 0..*   |       |
+| Name phonetic        | `phoneticNameIdentifier`  | see 2.1.1 | 0..*   |       |
+| Date/place of birth  | `dateAndPlaceOfBirth`          | see 2.1.2 | 0..1   |       |
+| Country of residence | `countryOfResidence` | String(2) | 0/1..1 | 2     |
+
+**Rules:**
+
+1. `nameIdentifier` must have at least one sub element where `nameIdentifierType` (see 2.1.1) has the value `LEGL`.
+2. `countryOfResidence` must be formatted as per ISO 3166-1 alpha-2.
+
+#### 2.1.1. Natural Person Name
+
+| Level 3                  | Name             | Type        | Mult. | Rules |
+| :----------------------- | :--------------- | :---------- | :---- | :---- |
+| Primary name             | `primaryIdentifier`   | String(100) | 1..1  |       |
+| Secondary name           | `secondaryIdentifier` | String(100) | 0..1  |       |
+| Natural person name type | `nameIdentifierType`      | see [3.1](#31-natural-person-name-type)     | 1..1  |       |
+
+#### 2.1.2 Daten and Place of Birth
+
+| Level 3        | Name         | Type       | Mult. | Rules |
+| :------------- | :----------- | :--------- | :---- | :---- |
+| Date of birth  | `dateOfBirth`  | String(10) | 1..1  | 1     |
+| Place of birth | `placeOfBirth` | String(70) | 1..1  |       |
+
+**Rules:**
+
+1. `dateOfBirth` must be a date prior to the current date and formatted as per ISO 8601 (YYYY-MM-DD).
+
+### 2.2. Legal Person
+
+| Level 2                 | Name            | Type      | Mult.  | Rules |
+| :---------------------- | :-------------- | :-------- | :----- | :---- |
+| Name                    | `nameIdentifier`          | see 2.2.1 | 1..*   | 1     |
+| Name local              | `name_local`    | see 2.2.1 | 0..*   |       |
+| Name phonetic           | `name_phonetic` | see 2.2.1 | 0..*   |       |
+| Country of registration | `countryOfRegistration`      | String(2) | 0/1..1 | 2     |
+
+**Rules:**
+
+1. `nameIdentifier` must have at least one sub element where `legalPersonNameIdentifierType` (see 2.2.1) has the value `LEGL`.
+2. `countryOfRegistration` must be formatted as per ISO 3166-1 alpha-2.
+
+#### 2.2.1. Legal Person Name
+
+| Level 3                | Name           | Type        | Mult. | Rules |
+| :--------------------- | :------------- | :---------- | :---- | :---- |
+| Legal person name      | `legalPersonName`     | String(100) | 1..1  |       |
+| Legal person name type | `legalPersonNameIdentifierType` | see [3.2](#32-legal-person-name-type)     | 1..1  |       |
+
+### 2.3. Address
+
+| Level 2             | Name          | Type       | Mult. | Rules |
+| :------------------ | :------------ | :--------- | :---- | :---- |
+| Address type        | `addressType`    | see [3.3](#33-address-type-values)    | 1..1  |       |
+| Department          | `department`         | String(50) | 0..1  |       |
+| Sub department      | `subDepartment`     | String(70) | 0..1  |       |
+| Street name         | `streetName`      | String(70) | 0..1  | 1     |
+| Building number     | `buildingNumber`     | String(16) | 0..1  | 1     |
+| Building name       | `buildingName`        | String(35) | 0..1  | 1     |
+| Floor               | `floor`       | String(70) | 0..1  |       |
+| Post office box     | `postBox`         | String(16) | 0..1  |       |
+| Room                | `room`        | String(70) | 0..1  |       |
+| Post code           | `postcode`    | String(16) | 0..1  |       |
+| Town                | `townName`        | String(35) | 1..1  |       |
+| Town location       | `townLocationName`    | String(35) | 0..1  |       |
+| District            | `district`    | String(35) | 0..1  |       |
+| Country subdivision | `country_sub` | String(35) | 0..1  |       |
+| Address line        | `addressLine`    | String(70) | 0..7  | 1     |
+| Country             | `country`        | String(2)  | 1..1  | 2     |
+
+**Rules:**
+
+1. One of the following combinations of elements must be present: `streetName`/`buildingNumber` or `streetName`/`buildingName` or at least one occurrence of `addressLine`.
+2. `country` must be formatted as per ISO 3166-1 alpha-2.
+
+### 2.4. National Identification Type
+
+| Level 2                  | Name      | Type       | Mult. | Rules   |
+| :----------------------- | :-------- | :--------- | :---- | :------ |
+| National Identifier      | `nationalIdentifier`   | String(35) | 1..1  |         |
+| National Identifier Type | `nationalIdentifierType` | see [3.4](#34-national-identifier-type-values)    | 1..1  | 2, 3    |
+| Country of issue         | `countryOfIssue` | String(2)  | 0..1  | 1, 4    |
+| Registration Authority   | `registrationAuthority`  | String(8)  | 0..1  | 2, 3, 5 |
+
+**Rules:**
+
+1. If `legalPerson` is present in the parent element on level 1, `countryOfIssue` must not be present.
+2. If `legalPerson` is present in the parent element on level 1 and the value of `nationalIdentifierType` is not `LEIX` (see [3.4](#34-national-identifier-type-values)), `registrationAuthority` must be present.
+3. If the value of `nationalIdentifierType` is `LEIX` (see [3.4](#34-national-identifier-type-values)), `registrationAuthority` must not be present.
+4. `countryOfIssue` must be formatted as per ISO 3166-1 alpha-2.
+5. `registrationAuthority` must be a valid GLEIF Registration Authority Code (see: https://www.gleif.org/en/about-lei/code-lists/gleif-registration-authorities-list).
+
+### 2.5. Customer Identification Type
+
+| Level 2            | Name     | Type       | Mult. | Rules |
+| :----------------- | :------- | :--------- | :---- | :---- |
+| VAAN               | `vaan`   | String(24) | 0..1  | 1, 2  |                          |
+| Generic identifier | `customerIdentification` | String(50) | 0..1  | 1     |
+
+**Rules:**
+
+1. Either `vaan` or `customerIdentification` must be present, or both.
+2. `vaan` must be a VAAN as specified in [OVIP 2](ovip-0002.md).
+
+## 3. Code Tables
+
+### 3.1. Natural Person Name Type
+
+Identifies the nature of the name being specified for a natural person (IVMS Ref. *NaturalPersonNameTypeCode*).
+
+| Code   | Name          | Description                                                  |
+| :----- | :------------ | :----------------------------------------------------------- |
+| `ALIA` | Alias name    | A name other than the legal name by which a natural person is also known |
+| `BIRT` | Name at birth | The name given to a natural person at birth                  |
+| `MAID` | Maiden name   | The original name of a natural person who has changed their name after marriage |
+| `LEGL` | Legal name    | The name that identifies a natural person for legal, official or administrative purposes |
+| `MISC` | Unspecified   | A name by which a natural person may be known but cannot otherwise be categorized |
+
+### 3.2. Legal Person Name Type
+
+Identifies the nature of the name being specified for a legal person (IVMS Ref. *LegalPersonNameTypeCode*).
+
+| Code   | Name         | Description                                             |
+| :----- | :----------- | :------------------------------------------------------ |
+| `LEGL` | Legal name   | Official name under which an organization is registered |
+| `SHRT` | Short name   | Short name of the organization                          |
+| `TRAD` | Trading name | Name used by the organization for commercial purposes   |
+
+### 3.3. Address Type Values
+
+Identifies the nature of the address (IVMS Ref. *AddressTypeCode*).
+
+| Code   | Name        | Description                  |
+| :----- | :---------- | :--------------------------- |
+| `HOME` | Residential | Home address                 |
+| `BIZZ` | Business    | Business address             |
+| `GEOG` | Geographic  | Unspecified physical address |
+
+### 3.4. National Identifier Type Values
+
+Identifies the national identification type (IVMS Ref. *NationalIdentifierTypeCode*).
+
+| Code   | Name                               | Description                                                  |
+| :----- | :--------------------------------- | :----------------------------------------------------------- |
+| `ARNU` | Alien registration number          | Number assigned by a government agency to identify foreign nationals |
+| `CCPT` | Passport number                    | Number assigned by a passport authority                      |
+| `RAID` | Registration authority identifier  | Identifier of a legal entity as maintained by a registration entity |
+| `DRLC` | Driver license number              | Number assigned to a driver's license                        |
+| `FIIN` | Foreign investment identity number | Number assigned to a foreign investor (other than the alien number) |
+| `TXID` | Tax identification number          | Number assigned by a tax authority to an entity              |
+| `SOCS` | Social security number             | Number assigned by a social security agency                  |
+| `IDCD` | Identity card number               | Number assigned by a national authority to an identity card  |
+| `LEIX` | Legal Entity Identifier            | Legal Entity Identifier (LEI) as per ISO 17442               |
+| `MISC` | Unspecified                        | A national identifier which is known but cannot be categorized by the sender |
+
+# Backwards Compatibility
+
+The specification proposed in this OVIP is not backwards compatible.
+


### PR DESCRIPTION
As discussed in the last technical call, this PR proposes a new OVIP to improve compatibility with IVMS101.

All-in-all it's just a change in naming, otherwise, it stays the same as outlined in OVIP 13.

Closes https://github.com/OpenVASP/ovips/issues/27.